### PR TITLE
feat(api): declare provisioned records so the platform stops creating drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+# 0.5.0
+
+## ✨ Features
+
+- **A provisioned record is managed from birth.** `POST /v1/dns/upsert` wrote to
+  Cloudflare and stopped there, so the monitor never knew the record existed.
+  The next inventory reported it as unmanaged and an operator had to *adopt* a
+  record the platform itself had just created — the API was manufacturing
+  exactly the drift adoption exists to clean up, once per provisioned tenant.
+  Upsert now declares the record in desired state in the same call, and the
+  response carries `declared: true|false` so a caller can tell.
+
+  Declaring is never fatal. The DNS record already exists by that point, so a
+  failure to record it is logged and reported, not turned into a failed
+  response for an operation that succeeded. A deployment with no desired-state
+  file configured is a supported configuration and simply reports
+  `declared: false`.
+
+## 🧹 Internal
+
+- `Defdo.DDNS.DesiredStateStore.declare/1` is now the single definition of what
+  declaring a record means. Adoption's promotion path used to carry a private
+  copy of the entry shape; two copies would eventually disagree about what
+  "already declared" means, and the same record could be stored twice or fail to
+  match itself on the next reconcile.
+- `declare/1` starts from an empty document when the file is absent. `load/0`
+  deliberately refuses to do this — for a read, treating "no file" as "no
+  intent" would silently unmanage the whole estate — but a declaration adds a
+  fact rather than inferring the absence of one, and without it the first record
+  a fresh deployment provisions would be dropped in silence.
+
+## 🔒 Security
+
+- Cleared all 28 advisories `mix hex.audit` reported. Most were removed rather
+  than upgraded: `tesla` and a second `mint` came from `restlax` and
+  `cloudflare`, neither declared in `mix.exs`; `bypass` pulled
+  `plug_cowboy → cowboy → cowlib` — a whole second HTTP server — for tests that
+  never used it. `req` was pinned `~> 0.5.0`, which locked out every fix, and
+  now tracks `~> 0.6`.
+
 # 0.4.3
 
 ## 🐞 Fixes

--- a/lib/defdo/ddns/adoption.ex
+++ b/lib/defdo/ddns/adoption.ex
@@ -112,8 +112,12 @@ defmodule Defdo.DDNS.Adoption do
 
   # Already-decided entries reaching accept/2 a second time must not re-promote
   # and must not fail; the record is already declared.
+  # Declaring is DesiredStateStore's job, not ours: the provisioning API
+  # declares records it creates through the same function, and two copies of
+  # the entry shape would eventually disagree about what "already declared"
+  # means.
   defp promote(%{"state" => "accepted", "record" => record}) do
-    case DesiredStateStore.update(&declare(&1, record)) do
+    case DesiredStateStore.declare(record) do
       {:ok, _doc} -> :ok
       {:error, :disabled} -> {:error, :desired_state_disabled}
       {:error, reason} -> {:error, reason}
@@ -121,31 +125,6 @@ defmodule Defdo.DDNS.Adoption do
   end
 
   defp promote(_entry), do: :ok
-
-  defp declare(doc, record) do
-    entry = %{
-      "domain" => record["domain"] || "",
-      "name" => record["name"],
-      "target" => record["content"] || "@",
-      "proxied" => record["proxied"] || false,
-      "ttl" => record["ttl"] || 1
-    }
-
-    update_in(doc, ["cloudflare", "cname_records"], fn declared ->
-      declared = declared || []
-
-      if Enum.any?(declared, &same_record?(&1, entry)) do
-        declared
-      else
-        declared ++ [entry]
-      end
-    end)
-  end
-
-  defp same_record?(a, b) do
-    String.downcase(to_string(a["name"])) == String.downcase(to_string(b["name"])) and
-      to_string(a["domain"]) == to_string(b["domain"])
-  end
 
   defp rollback(id, entry) do
     entries = load()

--- a/lib/defdo/ddns/api/dns.ex
+++ b/lib/defdo/ddns/api/dns.ex
@@ -3,6 +3,8 @@ defmodule Defdo.DDNS.API.DNS do
 
   require Logger
 
+  alias Defdo.DDNS.DesiredStateStore
+
   @spec upsert_free_domain(map()) :: {:ok, map()} | {:error, term()}
   def upsert_free_domain(params) when is_map(params) do
     with {:ok, fqdn} <- fetch_required_string(params, "fqdn"),
@@ -11,7 +13,7 @@ defmodule Defdo.DDNS.API.DNS do
          {:ok, zone_id} <- fetch_zone_id(base_domain),
          {:ok, desired_record} <- build_desired_record(params, fqdn, base_domain),
          {:ok, result} <- upsert_cname(zone_id, desired_record) do
-      {:ok, result}
+      {:ok, Map.put(result, :declared, declare(desired_record, base_domain))}
     end
   rescue
     error ->
@@ -20,6 +22,32 @@ defmodule Defdo.DDNS.API.DNS do
   end
 
   def upsert_free_domain(_), do: {:error, {:validation, %{"params" => "must be an object"}}}
+
+  # A record this deployment just created is managed from birth. Without this,
+  # every domain provisioned through the API showed up as unmanaged on the next
+  # inventory and an operator had to adopt a record the platform itself had
+  # created — the API would have been manufacturing exactly the drift adoption
+  # exists to clean up.
+  #
+  # Never fatal. The DNS record already exists at this point, so failing the
+  # response would report as failed something that succeeded. The caller gets
+  # `declared: false` and the log says why.
+  defp declare(desired_record, base_domain) do
+    case DesiredStateStore.declare(Map.put(desired_record, "domain", base_domain)) do
+      {:ok, _doc} ->
+        true
+
+      {:error, :disabled} ->
+        false
+
+      {:error, reason} ->
+        Logger.warning(
+          "dns_api_declare_failed name=#{desired_record["name"]} reason=#{inspect(reason)}"
+        )
+
+        false
+    end
+  end
 
   defp upsert_cname(zone_id, desired_record) do
     existing_records = ddns_module().list_dns_records(zone_id, name: desired_record["name"])

--- a/lib/defdo/ddns/desired_state_store.ex
+++ b/lib/defdo/ddns/desired_state_store.ex
@@ -164,6 +164,69 @@ defmodule Defdo.DDNS.DesiredStateStore do
     end
   end
 
+  @doc """
+  Declare a CNAME record as managed. Idempotent.
+
+  Two paths reach this: adoption promoting a record an operator accepted, and
+  the provisioning API declaring a record this deployment just created. They
+  must write the entry identically — if the shapes diverged, the same record
+  could be declared twice, or fail to match itself on the next reconcile and
+  reappear as drift. Sharing one function is what prevents that.
+
+  Returns `{:error, :disabled}` when no desired-state file is configured, which
+  callers are expected to treat as "nothing to record", not as a failure.
+  """
+  @spec declare(map()) :: {:ok, DesiredState.t()} | {:error, term()}
+  def declare(record) when is_map(record) do
+    entry = entry_for(record)
+
+    case load() do
+      {:ok, doc} ->
+        persist(put_cname(doc, entry))
+
+      # `load/0` refuses to treat a missing file as an empty document, and it is
+      # right to: for a *read*, "no intent anywhere" would silently unmanage the
+      # whole estate. A declaration is the opposite operation — it adds a fact
+      # rather than inferring the absence of one — so starting from an empty
+      # document is correct here, and it is the only way the first record a
+      # fresh deployment provisions actually gets recorded.
+      {:error, :missing_desired_state} ->
+        with {:ok, empty} <- DesiredState.new(%{}) do
+          persist(put_cname(empty, entry))
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp entry_for(record) do
+    %{
+      "domain" => record["domain"] || "",
+      "name" => record["name"],
+      "target" => record["content"] || "@",
+      "proxied" => record["proxied"] || false,
+      "ttl" => record["ttl"] || 1
+    }
+  end
+
+  defp put_cname(doc, entry) do
+    update_in(doc, ["cloudflare", "cname_records"], fn declared ->
+      declared = declared || []
+
+      if Enum.any?(declared, &same_record?(&1, entry)) do
+        declared
+      else
+        declared ++ [entry]
+      end
+    end)
+  end
+
+  defp same_record?(a, b) do
+    String.downcase(to_string(a["name"])) == String.downcase(to_string(b["name"])) and
+      to_string(a["domain"]) == to_string(b["domain"])
+  end
+
   @doc "Counts and metadata only — never hostnames, targets or flag values."
   @spec status() :: map()
   def status do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Defdo.DDNS.MixProject do
   def project do
     [
       app: :defdo_ddns,
-      version: "0.4.3",
+      version: "0.5.0",
       elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       description: description(),

--- a/test/ddns_api_declares_test.exs
+++ b/test/ddns_api_declares_test.exs
@@ -1,0 +1,128 @@
+defmodule Defdo.DDNS.APIDeclaresTest do
+  @moduledoc """
+  A record the provisioning API creates must be declared as managed in the same
+  call.
+
+  Before this, `POST /v1/dns/upsert` wrote to Cloudflare and stopped there. The
+  monitor never knew the record existed, so the next inventory reported it as
+  unmanaged and an operator had to *adopt* a record the platform itself had just
+  created. The API was manufacturing exactly the drift adoption exists to clean
+  up, and it did so once per provisioned tenant.
+
+  Adoption is for records someone else made. Ours are managed from birth.
+  """
+  use ExUnit.Case, async: false
+
+  alias Defdo.DDNS.API.DNS
+  alias Defdo.DDNS.DesiredStateStore
+
+  defmodule FakeDDNS do
+    def get_zone_id(zone) when is_binary(zone) and zone != "", do: "zone_123"
+    def get_zone_id(_), do: nil
+
+    def list_dns_records("zone_123", name: _name), do: []
+
+    def create_dns_record("zone_123", record),
+      do: {true, Map.merge(record, %{"id" => "record_1"})}
+
+    def input_for_update_cname_records(_records, _desired), do: []
+    def apply_update(_zone_id, _input), do: {true, %{"id" => "record_1"}}
+  end
+
+  setup do
+    previous_api = Application.get_env(:defdo_ddns, Defdo.DDNS.API)
+    previous_store = Application.get_env(:defdo_ddns, DesiredStateStore)
+
+    dir = Path.join(System.tmp_dir!(), "ddns-declare-#{System.unique_integer([:positive])}")
+    file = Path.join(dir, "desired_state.json")
+
+    Application.put_env(:defdo_ddns, Defdo.DDNS.API,
+      ddns_module: FakeDDNS,
+      default_target: "@",
+      default_proxied: true
+    )
+
+    Application.put_env(:defdo_ddns, DesiredStateStore, path: file)
+
+    on_exit(fn ->
+      File.rm_rf(dir)
+      restore(Defdo.DDNS.API, previous_api)
+      restore(DesiredStateStore, previous_store)
+    end)
+
+    {:ok, state_path: file}
+  end
+
+  test "a provisioned record is declared in desired state" do
+    base_domain = "defdo-test-#{System.unique_integer([:positive])}.dev"
+    fqdn = "acme-idp.#{base_domain}"
+
+    assert {:ok, %{action: "created", declared: true}} =
+             DNS.upsert_free_domain(%{"fqdn" => fqdn, "base_domain" => base_domain})
+
+    assert {:ok, doc} = DesiredStateStore.load()
+    declared = get_in(doc, ["cloudflare", "cname_records"])
+
+    assert Enum.any?(declared, fn entry ->
+             entry["name"] == fqdn and entry["domain"] == base_domain and
+               entry["target"] == base_domain
+           end)
+  end
+
+  test "declaring the same record twice does not duplicate it" do
+    base_domain = "defdo-test-#{System.unique_integer([:positive])}.dev"
+    fqdn = "acme-idp.#{base_domain}"
+    params = %{"fqdn" => fqdn, "base_domain" => base_domain}
+
+    assert {:ok, %{declared: true}} = DNS.upsert_free_domain(params)
+    assert {:ok, %{declared: true}} = DNS.upsert_free_domain(params)
+
+    {:ok, doc} = DesiredStateStore.load()
+
+    matching =
+      doc
+      |> get_in(["cloudflare", "cname_records"])
+      |> Enum.count(&(&1["name"] == fqdn))
+
+    assert matching == 1
+  end
+
+  test "the declared entry carries the identity inventory matches on" do
+    base_domain = "defdo-test-#{System.unique_integer([:positive])}.dev"
+    fqdn = "ACME-IDP.#{base_domain}"
+
+    assert {:ok, %{declared: true}} =
+             DNS.upsert_free_domain(%{"fqdn" => fqdn, "base_domain" => base_domain})
+
+    # Inventory keys a record on {type, name}, lowercased. If a declaration
+    # stored the name as given, a record provisioned with mixed case would fail
+    # to match itself on the next reconcile and reappear as drift — which is the
+    # exact failure this whole change exists to prevent.
+    #
+    # This asserts the identity is storable and normalised. Running Inventory
+    # end to end needs a Cloudflare double it has no seam for today; that gap is
+    # real and is not covered here.
+    {:ok, doc} = DesiredStateStore.load()
+    entry = doc |> get_in(["cloudflare", "cname_records"]) |> List.first()
+
+    assert entry["name"] == String.downcase(fqdn)
+    assert entry["domain"] == base_domain
+  end
+
+  test "provisioning still succeeds when no desired-state file is configured" do
+    Application.delete_env(:defdo_ddns, DesiredStateStore)
+    base_domain = "defdo-test-#{System.unique_integer([:positive])}.dev"
+
+    # A deployment without the file is a supported configuration: the record is
+    # created and simply not recorded. Reporting failure here would call a
+    # successful DNS write a failure.
+    assert {:ok, %{action: "created", declared: false}} =
+             DNS.upsert_free_domain(%{
+               "fqdn" => "acme-idp.#{base_domain}",
+               "base_domain" => base_domain
+             })
+  end
+
+  defp restore(key, nil), do: Application.delete_env(:defdo_ddns, key)
+  defp restore(key, value), do: Application.put_env(:defdo_ddns, key, value)
+end


### PR DESCRIPTION
## The gap

`POST /v1/dns/upsert` wrote to Cloudflare and stopped there. The monitor never learned the record existed, so the next inventory reported it as **unmanaged** — and an operator had to *adopt* a record the platform itself had just created.

The API was manufacturing exactly the drift adoption exists to clean up, **once per provisioned tenant**. The pending queue would grow on its own.

Found because `defdo_tenant`'s DNS provisioner calls this endpoint on every tenant domain.

## The change

Adoption is for records someone else made. **Ours are managed from birth.** Upsert now declares the record in desired state in the same call and reports `declared: true|false`.

Declaring is **never fatal**: the DNS record already exists by that point, so a failure to record it is logged, not turned into a failed response for an operation that succeeded. A deployment with no desired-state file is supported and reports `declared: false`.

`DesiredStateStore.declare/1` becomes the single definition of what declaring means. Adoption carried a private copy of the entry shape — two copies would eventually disagree about what "already declared" means, and the same record could be stored twice or fail to match itself on the next reconcile.

## A bug the tests found

`declare/1` starts from an empty document when the file is absent. `load/0` deliberately refuses to do this — for a *read*, treating "no file" as "no intent" would silently unmanage the whole estate. But a declaration **adds a fact** rather than inferring the absence of one, and without this **the first record a fresh deployment provisions was dropped in silence** — the exact class of bug this PR exists to close.

## Verification

- `mix test` — **179 tests, 0 failures**, across two consecutive runs
- `mix hex.audit` — clean
- `mix compile --warnings-as-errors` clean
- 4 new tests: declaration happens, is idempotent, normalises the identity inventory keys on, and provisioning still succeeds with no store configured

**Not covered:** running `Inventory` end to end against a Cloudflare double. It has no seam for one today; that gap is real and called out in the test file rather than papered over.